### PR TITLE
The pygments config option is now called highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,5 @@ exclude:
   - README.md
   - CONTRIBUTING.md
 markdown: redcarpet
-pygments: true
+highlighter: pygments
 permalink: none


### PR DESCRIPTION
In Jekyll 2.0, which is used on GitHub pages now, the pygments config option is now called highlighter. I've updated that to remove the warning when generating the site locally.
