### PR TITLE
Use Kramdown as the markdown renderer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 exclude:
   - README.md
   - CONTRIBUTING.md
-markdown: redcarpet
 highlighter: pygments
 permalink: none


### PR DESCRIPTION
Now we're on Jekyll 2.2.0 [Kramdown](http://kramdown.gettalong.org/) is the default markdown renderer, we can enable it simply by removing the current markdown option from the config.
