### PR TITLE
Make use of new template defaults in Jekyll 2.2.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,9 @@ exclude:
   - CONTRIBUTING.md
 highlighter: pygments
 permalink: none
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      layout: "default"

--- a/_posts/2013-05-02-jsconf2013.md
+++ b/_posts/2013-05-02-jsconf2013.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: JSConf 2013 Recap
 introTitle: JSConf 2013 Recap
 category: events
@@ -54,4 +53,3 @@ We didn't get to see all of them! If your robot isn't here please [tweet](/core.
 
 ### Other Bots
 Coming soon!
-

--- a/conduct.html
+++ b/conduct.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: NodeBots Code of Conduct
 introTitle: Code of Conduct
 ---

--- a/core.html
+++ b/core.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: NodeBots Core Team
 introTitle: Your NodeBot Experts
 ---

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: NodeBots - The Rise of JS Robotics
 introTitle: Robots powered by JavaScript
 ---
@@ -34,7 +33,7 @@ introTitle: Robots powered by JavaScript
 <ul>
   <li>
     <a href="http://nodebotsgt.tumblr.com/">NodeBots Guatemala</a> - Guatemala
-  </li>    
+  </li>
   <li>
     <a href="http://nodebotsmed.tumblr.com/">NodeBots Medellín</a> - Colombia
   </li>
@@ -60,7 +59,7 @@ introTitle: Robots powered by JavaScript
     or <a href="#join">start your own!</a>
   </li>
 </ul>
-  
+
   <h3>Past Events</h3>
   <ul>
     <li><a href="https://github.com/nodebots/nodebotsday">Nodebots Day</a> - July 27th 2013 (worldwide)</li>

--- a/projects.html
+++ b/projects.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Awesome Projects
 introTitle: Projects built with johnny-five
 ---

--- a/sumo.html
+++ b/sumo.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Sumo Rules
 introTitle: Sumo Competition Rules
 ---


### PR DESCRIPTION
All pages default to using the `default.html` layout now, thanks to the new template defaults in Jekyll 2.2.0.
