### PR TITLE
Remove Old DC Event Link in meetups.json

### DIFF
--- a/_data/meetups.json
+++ b/_data/meetups.json
@@ -129,14 +129,6 @@
   },
   {
     "coords":[
-      38.9,
-      -77.03
-    ],
-    "name":"NodeBots DC",
-    "url":"https://ti.to/nodebots-dc/nodebots-day-2014"
-  },
-  {
-    "coords":[
       45.42,
       -75.69
     ],


### PR DESCRIPTION
I was checking out the change to the site based on my recently merged pull request (#68) and noticed that the map had a link for the 2014 incarnation of NodeBots Day in DC. I removed that reference.
